### PR TITLE
Fix build with OpenJDK versions >= 11

### DIFF
--- a/ocpp-common/pom.xml
+++ b/ocpp-common/pom.xml
@@ -59,6 +59,18 @@
             <version>1.2.3</version>
         </dependency>
 
+	<!-- To make OpenJDK >11 build work -->
+        <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+	<dependency>
+	    <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
         <!-- Tests -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
As these no longer include certain required packages within the standard library.