### PR TITLE
Remove additional inlet properties from Start/StopTransactionRequest

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
@@ -215,31 +215,6 @@ public class ClientCoreProfile implements Profile {
   }
 
   /**
-   * Create a client {@link StartTransactionRequest} with required values.
-   *
-   * @param connectorId required. Identification of the connector.
-   * @param idTag required. Authorization identification tag.
-   * @param meterStart required. The initial value of the meter.
-   * @param inletExportStart not required. The initial value of inlet exported Wh.
-   * @param inletImportStart not required. The initial value of inlet imported Wh.
-   * @param timestamp required. Time of start.
-   * @return an instance of {@link StartTransactionRequest}.
-   * @see StartTransactionRequest
-   * @see StartTransactionFeature
-   */
-  public StartTransactionRequest createExtendedStartTransactionRequest(
-          Integer connectorId, String idTag, Integer meterStart, Integer inletExportStart, Integer inletImportStart, Calendar timestamp) {
-    StartTransactionRequest request = new StartTransactionRequest();
-    request.setConnectorId(connectorId);
-    request.setIdTag(idTag);
-    request.setMeterStart(meterStart);
-    request.setInletExportStart(inletExportStart);
-    request.setInletImportStart(inletImportStart);
-    request.setTimestamp(timestamp);
-    return request;
-  }
-
-  /**
    * Create a client {@link StatusNotificationRequest} with required values.
    *
    * @param connectorId required. Identification of the connector.
@@ -270,27 +245,6 @@ public class ClientCoreProfile implements Profile {
       int meterStop, Calendar timestamp, int transactionId) {
     StopTransactionRequest request = new StopTransactionRequest();
     request.setMeterStop(meterStop);
-    request.setTimestamp(timestamp);
-    request.setTransactionId(transactionId);
-    return request;
-  }
-
-  /**
-   * Create a client {@link StopTransactionRequest} with required values.
-   *
-   * @param meterStop required. The final value of the meter.
-   * @param inletExportStop not required. The final value of inlet exported Wh.
-   * @param inletImportStop not required. The final value of inlet imported Wh.
-   * @param timestamp required. Time of stop.
-   * @param transactionId required. The identification of the transaction.
-   * @return an instance of {@link StopTransactionRequest}.
-   */
-  public StopTransactionRequest createExtendedStopTransactionRequest(
-          int meterStop, int inletExportStop, int inletImportStop, Calendar timestamp, int transactionId) {
-    StopTransactionRequest request = new StopTransactionRequest();
-    request.setMeterStop(meterStop);
-    request.setInletExportStop(inletExportStop);
-    request.setInletImportStop(inletImportStop);
     request.setTimestamp(timestamp);
     request.setTransactionId(transactionId);
     return request;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
@@ -52,8 +52,6 @@ public class StartTransactionRequest implements Request {
   private Integer meterStart;
   private Integer reservationId;
   private Calendar timestamp;
-  private Integer inletExportStart;
-  private Integer inletImportStart;
 
   @Override
   public boolean validate() {
@@ -61,10 +59,6 @@ public class StartTransactionRequest implements Request {
     valid &= ModelUtil.validate(idTag, 20);
     valid &= meterStart != null;
     valid &= timestamp != null;
-
-    // If inlet values are present in meter request, both must be present
-    valid &= ((inletExportStart == null && inletImportStart == null) ||
-              (inletExportStart != null && inletImportStart != null));
 
     if (!valid) {
       System.out.println("Processing bad StartTransactionRequest anyways!");
@@ -138,44 +132,6 @@ public class StartTransactionRequest implements Request {
   }
 
   /**
-   * This contains the inlet export value in Wh for the supply at start of the transaction.
-   *
-   * @return Export Wh at start.
-   */
-  public Integer getInletExportStart() {
-    return inletExportStart;
-  }
-
-  /**
-   * Optional. This contains the inlet export value in Wh for the supply at start of the transaction.
-   *
-   * @param inletExportStart integer, export Wh at start.
-   */
-  @XmlElement
-  public void setInletExportStart(Integer inletExportStart) {
-    this.inletExportStart = inletExportStart;
-  }
-
-  /**
-   * This contains the inlet import value in Wh for the supply at start of the transaction.
-   *
-   * @return Import Wh at start.
-   */
-  public Integer getInletImportStart() {
-    return inletImportStart;
-  }
-
-  /**
-   * Optional. This contains the inlet import value in Wh for the supply at start of the transaction.
-   *
-   * @param inletImportStart integer, import Wh at start.
-   */
-  @XmlElement
-  public void setInletImportStart(Integer inletImportStart) {
-    this.inletImportStart = inletImportStart;
-  }
-
-  /**
    * This contains the id of the reservation that terminates as a result of this transaction.
    *
    * @return reservation.
@@ -238,9 +194,7 @@ public class StartTransactionRequest implements Request {
         && Objects.equals(idTag, that.idTag)
         && Objects.equals(meterStart, that.meterStart)
         && Objects.equals(reservationId, that.reservationId)
-        && Objects.equals(timestamp, that.timestamp)
-        && Objects.equals(inletExportStart, that.inletExportStart)
-        && Objects.equals(inletImportStart, that.inletImportStart);
+        && Objects.equals(timestamp, that.timestamp);
   }
 
   @Override
@@ -257,8 +211,6 @@ public class StartTransactionRequest implements Request {
         .add("reservationId", reservationId)
         .add("timestamp", timestamp)
         .add("isValid", validate())
-        .add("inletExportStart", inletExportStart)
-        .add("inletImportStart", inletImportStart)
         .toString();
   }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
@@ -51,19 +51,10 @@ public class StopTransactionRequest implements Request {
   private Reason reason;
   private MeterValue[] transactionData;
 
-  private Integer inletExportStop;
-
-  private Integer inletImportStop;
-
   @Override
   public boolean validate() {
     boolean valid = meterStop != null;
     valid &= timestamp != null;
-
-    // If inlet values are present in meter request, both must be present
-    valid &= ((inletExportStop == null && inletImportStop == null) ||
-              (inletExportStop != null && inletImportStop != null));
-
     valid &= transactionId != null;
     if (transactionData != null) {
       for (MeterValue meterValue : transactionData) {
@@ -118,44 +109,6 @@ public class StopTransactionRequest implements Request {
   @XmlElement
   public void setMeterStop(Integer meterStop) {
     this.meterStop = meterStop;
-  }
-
-  /**
-   * This contains the inlet export value in Wh for the connector at end of the transaction.
-   *
-   * @return Export Wh at end.
-   */
-  public Integer getInletExportStop() {
-    return inletExportStop;
-  }
-
-  /**
-   * Optional. This contains the inlet export value in Wh for the connector at end of the transaction.
-   *
-   * @param inletExportStop integer, export value in Wh.
-   */
-  @XmlElement
-  public void setInletExportStop(Integer inletExportStop) {
-    this.inletExportStop = inletExportStop;
-  }
-
-  /**
-   * This contains the inlet import value in Wh for the connector at end of the transaction.
-   *
-   * @return Import Wh at end.
-   */
-  public Integer getInletImportStop() {
-    return inletImportStop;
-  }
-
-  /**
-   * Optional. This contains the inlet import value in Wh for the connector at end of the transaction.
-   *
-   * @param inletImportStop integer, import value in Wh.
-   */
-  @XmlElement
-  public void setInletImportStop(Integer inletImportStop) {
-    this.inletImportStop = inletImportStop;
   }
 
   /**
@@ -271,9 +224,7 @@ public class StopTransactionRequest implements Request {
         && Objects.equals(timestamp, that.timestamp)
         && Objects.equals(transactionId, that.transactionId)
         && reason == that.reason
-        && Arrays.equals(transactionData, that.transactionData)
-        && Objects.equals(inletExportStop, that.inletExportStop)
-        && Objects.equals(inletImportStop, that.inletImportStop);
+        && Arrays.equals(transactionData, that.transactionData);
   }
 
   @Override
@@ -291,8 +242,6 @@ public class StopTransactionRequest implements Request {
         .add("reason", reason)
         .add("transactionData", transactionData)
         .add("isValid", validate())
-        .add("inletExportStop", inletExportStop)
-        .add("inletImportStop", inletImportStop)
         .toString();
   }
 }


### PR DESCRIPTION
Remove the inlet values and utility functions for start and stop transactions that were added to
the library, as they break the specification.