### PR TITLE
feat: [FIR-979] add details to OCPP request object which holds messageId and other request details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ java-docs
 
 # Should be ignored when using IDE-independent build system such as Maven or Gradle
 .idea/
-*.iml
+../**/*.iml
 /.gradle
 */build

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -135,7 +135,7 @@ public class WebSocketListener implements Listener {
 
           @Override
           public void onMessage(WebSocket webSocket, String message) {
-            sockets.get(webSocket).relay(message);
+            sockets.get(webSocket).relay(message, null);
           }
 
           @Override

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketReceiver.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketReceiver.java
@@ -25,6 +25,8 @@ package eu.chargetime.ocpp;
    SOFTWARE.
 */
 
+import eu.chargetime.ocpp.model.RequestDetails;
+
 public class WebSocketReceiver implements Receiver {
 
   private RadioEvents handler;
@@ -40,8 +42,8 @@ public class WebSocketReceiver implements Receiver {
     handler.disconnected();
   }
 
-  public void relay(String message) {
-    handler.receivedMessage(message);
+  public void relay(String message, RequestDetails details) {
+    handler.receivedMessage(message, details);
   }
 
   @Override

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -73,7 +73,7 @@ public class WebSocketTransmitter implements Transmitter {
 
           @Override
           public void onMessage(String message) {
-            events.receivedMessage(message);
+            events.receivedMessage(message, null);
           }
 
           @Override

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -271,7 +271,7 @@ public abstract class Communicator {
     }
 
     @Override
-    public void receivedMessage(Object input) {
+    public void receivedMessage(Object input, RequestDetails details) {
       Message message = parse(input);
       if (message != null) {
         Object payload = message.getPayload();
@@ -290,7 +290,7 @@ public abstract class Communicator {
             call.getId(), call.getErrorCode(), call.getErrorDescription(), call.getRawPayload());
       } else if (message instanceof CallMessage) {
         CallMessage call = (CallMessage) message;
-        events.onCall(call.getId(), call.getAction(), call.getPayload());
+        events.onCall(call.getId(), call.getAction(), call.getPayload(), details);
       }
     }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/CommunicatorEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/CommunicatorEvents.java
@@ -27,6 +27,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import eu.chargetime.ocpp.model.RequestDetails;
+
 /** Call back handler for communicator events. */
 public interface CommunicatorEvents {
   /**
@@ -51,7 +53,7 @@ public interface CommunicatorEvents {
    * @param action action name used to identify the feature.
    * @param payload raw payload.
    */
-  void onCall(String id, String action, Object payload);
+  void onCall(String id, String action, Object payload, RequestDetails details);
 
   /**
    * Handle call error.

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/RadioEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/RadioEvents.java
@@ -27,6 +27,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import eu.chargetime.ocpp.model.RequestDetails;
+
 /** Transmitter related events. */
 public interface RadioEvents {
   /** Connection established. */
@@ -37,7 +39,7 @@ public interface RadioEvents {
    *
    * @param message message object.
    */
-  void receivedMessage(Object message);
+  void receivedMessage(Object message, RequestDetails details);
 
   /** Disconnected from node. */
   void disconnected();

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
@@ -29,6 +29,7 @@ SOFTWARE.
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestDetails;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Optional;
 import java.util.UUID;
@@ -189,7 +190,7 @@ public class Session implements ISession {
     }
 
     @Override
-    public synchronized void onCall(String id, String action, Object payload) {
+    public synchronized void onCall(String id, String action, Object payload, RequestDetails details) {
       Optional<Feature> featureOptional = featureRepository.findFeature(action);
       if (!featureOptional.isPresent()) {
         communicator.sendCallError(
@@ -199,6 +200,7 @@ public class Session implements ISession {
           Request request =
               communicator.unpackPayload(payload, featureOptional.get().getRequestType());
           request.setRequestId(id);
+          request.setDetails(details);
           if (request.validate()) {
             CompletableFuture<Confirmation> promise = dispatcher.handleRequest(request);
             promise.whenComplete(new ConfirmationHandler(id, action, communicator));

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/DetailedRequest.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/DetailedRequest.java
@@ -1,0 +1,35 @@
+package eu.chargetime.ocpp.model;
+
+public abstract class DetailedRequest implements Request {
+
+  /**
+   * Unique request ID for each request
+   */
+  private String requestId;
+
+  /**
+   * Request details that holds all kinds of optional details for a request
+   */
+  private RequestDetails details;
+
+  @Override
+  public void setDetails(RequestDetails details){
+    this.details = details;
+  }
+
+  @Override
+  public RequestDetails getDetails(){
+    return details;
+  }
+
+  @Override
+  public void setRequestId(String requestId){
+    this.requestId = requestId;
+  }
+
+  @Override
+  public String getRequestId(){
+    return requestId;
+  }
+
+}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/MessageState.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/MessageState.java
@@ -1,0 +1,5 @@
+package eu.chargetime.ocpp.model;
+
+public enum MessageState {
+	INVALID_MEMORY, INVALID_CRC
+}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Request.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Request.java
@@ -40,4 +40,8 @@ public interface Request extends Validatable {
    * @return the unique identifier of the request that was used when it was transmitted over the network.
    */
   String getRequestId();
+
+  void setDetails(RequestDetails details);
+
+  RequestDetails getDetails();
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/RequestDetails.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/RequestDetails.java
@@ -1,0 +1,34 @@
+package eu.chargetime.ocpp.model;
+
+import java.util.Set;
+
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
+/**
+ * Holds additional details that should be included alongside the [Request] payload
+ */
+public class RequestDetails {
+
+	public RequestDetails(){}
+
+	public RequestDetails(Set<MessageState> states){
+		this.states = states;
+	}
+
+	private Set<MessageState> states;
+
+	public void setStates(Set<MessageState> states){
+		this.states = states;
+	}
+
+	public Set<MessageState> getStates(){
+		return states;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("invalidStates", states)
+				.toString();
+	}
+}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestRequest.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestRequest.java
@@ -27,12 +27,7 @@ package eu.chargetime.ocpp.model;
  */
 
 /** Test implementation of the Request interface. Used for tests. */
-public class TestRequest implements Request {
-  @Override
-  public void setRequestId(String requestId) { }
-
-  @Override
-  public String getRequestId(){ return null; }
+public class TestRequest extends DetailedRequest {
 
   @Override
   public boolean validate() {

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
@@ -8,6 +8,7 @@ import eu.chargetime.ocpp.*;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestDetails;
 import eu.chargetime.ocpp.model.TestRequest;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -93,6 +94,12 @@ public class SessionTest {
           public String getRequestId(){ return null; }
 
           @Override
+          public void setDetails(RequestDetails details) { }
+
+          @Override
+          public RequestDetails getDetails() { return null; }
+
+          @Override
           public boolean transactionRelated() {
             return false;
           }
@@ -158,7 +165,7 @@ public class SessionTest {
     when(communicator.unpackPayload(any(), any())).thenReturn(new TestRequest());
 
     // When
-    eventHandler.onCall(someId, null, null);
+    eventHandler.onCall(someId, null, null, null);
 
     // then
     verify(communicator, times(1)).sendCallError(eq(someId), anyString(), anyString(), anyString());
@@ -177,7 +184,7 @@ public class SessionTest {
     when(communicator.unpackPayload(any(), any())).thenReturn(new TestRequest());
 
     // When
-    eventHandler.onCall(someId, null, null);
+    eventHandler.onCall(someId, null, null, null);
 
     // then
     verify(communicator, times(1)).sendCallResult(anyString(), anyString(), eq(aConfirmation));
@@ -197,7 +204,7 @@ public class SessionTest {
     when(communicator.unpackPayload(any(), any())).thenReturn(new TestRequest());
 
     // When
-    eventHandler.onCall(someId, null, null);
+    eventHandler.onCall(someId, null, null, null);
 
     // then
     verify(communicator, times(1)).sendCallError(eq(someId), anyString(), anyString(), anyString());
@@ -219,7 +226,7 @@ public class SessionTest {
     when(featureRepository.findFeature(any())).thenReturn(Optional.empty());
 
     // When
-    eventHandler.onCall(someId, null, null);
+    eventHandler.onCall(someId, null, null, null);
 
     // Then
     verify(communicator, times(1)).sendCallError(eq(someId), anyString(), anyString(), anyString());

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
@@ -81,7 +81,7 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
 
   @Override
   void forwardMessage(SOAPMessage message) {
-    events.receivedMessage(message);
+    events.receivedMessage(message, null);
   }
 
   @Override
@@ -91,7 +91,7 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
     new Thread(
             () -> {
               try {
-                events.receivedMessage(soapConnection.call(message, url));
+                events.receivedMessage(soapConnection.call(message, url), null);
               } catch (SOAPException e) {
                 disconnect();
               }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
@@ -85,7 +85,7 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
             () -> {
               try {
                 SOAPMessage response = soapConnection.call(message, url);
-                events.receivedMessage(response);
+                events.receivedMessage(response, null);
               } catch (SOAPException e) {
                 logger.warn("sendRequest() failed", e);
                 disconnect();
@@ -96,6 +96,6 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
 
   @Override
   protected void forwardMessage(SOAPMessage message) {
-    events.receivedMessage(message);
+    events.receivedMessage(message, null);
   }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeRequest.java
@@ -1,7 +1,7 @@
 package eu.chargetime.ocpp.model.core;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -37,26 +37,12 @@ SOFTWARE.
 
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class AuthorizeRequest implements Request {
+public class AuthorizeRequest extends DetailedRequest {
 
   private static final int IDTAG_MAX_LENGTH = 20;
   private static final String ERROR_MESSAGE = "Exceeded limit of " + IDTAG_MAX_LENGTH + " chars";
 
   private String idTag;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public AuthorizeRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationRequest.java
@@ -28,7 +28,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -50,7 +50,7 @@ import javax.xml.bind.annotation.XmlType;
       "meterType",
       "meterSerialNumber"
     })
-public class BootNotificationRequest implements Request {
+public class BootNotificationRequest extends DetailedRequest {
 
   private static final int STRING_20_CHAR_MAX_LENGTH = 20;
   private static final int STRING_25_CHAR_MAX_LENGTH = 25;
@@ -66,20 +66,6 @@ public class BootNotificationRequest implements Request {
   private String imsi;
   private String meterSerialNumber;
   private String meterType;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public BootNotificationRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
@@ -27,33 +27,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class ChangeAvailabilityRequest implements Request {
+public class ChangeAvailabilityRequest extends DetailedRequest {
 
   private int connectorId = -1;
   private AvailabilityType type;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * The id of the connector for which availability needs to change. Id '0' (zero) is used if the

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationRequest.java
@@ -26,14 +26,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.ModelUtil;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.ModelUtil;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /**
  * Sent by Central System to Charge Point.
@@ -43,7 +45,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement
 @XmlType(propOrder = {"key", "value"})
-public class ChangeConfigurationRequest implements Request {
+public class ChangeConfigurationRequest extends DetailedRequest {
 
   private static final String ERROR_MESSAGE = "Exceeded limit of %s chars";
   private static final int KEY_MAX_LENGTH = 50;
@@ -51,20 +53,6 @@ public class ChangeConfigurationRequest implements Request {
 
   private String key;
   private String value;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * The name of the configuration setting to change.

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheRequest.java
@@ -27,28 +27,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlRootElement;
+
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /** Sent by the Central System to the Charge Point. Request holds no values and is always valid. */
 @XmlRootElement
-public class ClearCacheRequest implements Request {
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
+public class ClearCacheRequest extends DetailedRequest {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -38,27 +38,13 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent either by the Central System to the Charge Point or vice versa. */
 @XmlRootElement
 @XmlType(propOrder = {"vendorId", "messageId", "data"})
-public class DataTransferRequest implements Request {
+public class DataTransferRequest extends DetailedRequest {
 
   private static final String ERROR_MESSAGE = "Exceeded limit of %s chars";
 
   private String vendorId;
   private String messageId;
   private String data;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public DataTransferRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationRequest.java
@@ -27,33 +27,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.ModelUtil;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.ModelUtil;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the the Central System to the Charge Point. */
 @XmlRootElement
-public class GetConfigurationRequest implements Request {
+public class GetConfigurationRequest extends DetailedRequest {
 
   private String[] key;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * List of keys for which the configuration value is requested.

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatRequest.java
@@ -26,28 +26,14 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System. Request holds no values and is always valid. */
 @XmlRootElement
-public class HeartbeatRequest implements Request {
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
+public class HeartbeatRequest extends DetailedRequest {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
@@ -42,25 +42,11 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "transactionId", "meterValue"})
-public class MeterValuesRequest implements Request {
+public class MeterValuesRequest extends DetailedRequest {
 
   private int connectorId;
   private int transactionId;
   private MeterValue[] meterValue;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionRequest.java
@@ -26,37 +26,25 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.ModelUtil;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.ModelUtil;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent to Charge Point by Central System. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "idTag", "chargingProfile"})
-public class RemoteStartTransactionRequest implements Request {
+public class RemoteStartTransactionRequest extends DetailedRequest {
 
   private Integer connectorId;
   private String idTag;
   private ChargingProfile chargingProfile;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionRequest.java
@@ -26,30 +26,18 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** sent to Charge Point by Central System. */
 @XmlRootElement
-public class RemoteStopTransactionRequest implements Request {
+public class RemoteStopTransactionRequest extends DetailedRequest {
   private Integer transactionId;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetRequest.java
@@ -26,30 +26,18 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class ResetRequest implements Request {
+public class ResetRequest extends DetailedRequest {
   private ResetType type;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * This contains the type of reset that the Charge Point should perform.

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
@@ -34,14 +34,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "idTag", "timestamp", "meterStart", "reservationId"})
-public class StartTransactionRequest implements Request {
+public class StartTransactionRequest extends DetailedRequest {
 
   private static final int IDTAG_MAX_LENGTH = 20;
   private static final String IDTAG_ERROR_MESSAGE =
@@ -52,20 +52,6 @@ public class StartTransactionRequest implements Request {
   private Integer meterStart;
   private Integer reservationId;
   private Calendar timestamp;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Calendar;
@@ -48,7 +48,7 @@ import javax.xml.bind.annotation.XmlType;
       "vendorId",
       "vendorErrorCode"
     })
-public class StatusNotificationRequest implements Request {
+public class StatusNotificationRequest extends DetailedRequest {
 
   private static final String ERROR_MESSAGE = "Exceeds limit of %s chars";
 
@@ -59,20 +59,6 @@ public class StatusNotificationRequest implements Request {
   private Calendar timestamp;
   private String vendorId;
   private String vendorErrorCode;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
@@ -43,27 +43,13 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 @XmlRootElement
 @XmlType(
     propOrder = {"transactionId", "idTag", "timestamp", "meterStop", "reason", "transactionData"})
-public class StopTransactionRequest implements Request {
+public class StopTransactionRequest extends DetailedRequest {
   private String idTag;
   private Integer meterStop;
   private Calendar timestamp;
   private Integer transactionId;
   private Reason reason;
   private MeterValue[] transactionData;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorRequest.java
@@ -26,31 +26,19 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class UnlockConnectorRequest implements Request {
+public class UnlockConnectorRequest extends DetailedRequest {
   private Integer connectorId;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationRequest.java
@@ -26,32 +26,20 @@ package eu.chargetime.ocpp.model.firmware;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class DiagnosticsStatusNotificationRequest implements Request {
+public class DiagnosticsStatusNotificationRequest extends DetailedRequest {
 
   private DiagnosticsStatus status;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public DiagnosticsStatusNotificationRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationRequest.java
@@ -26,32 +26,20 @@ package eu.chargetime.ocpp.model.firmware;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class FirmwareStatusNotificationRequest implements Request {
+public class FirmwareStatusNotificationRequest extends DetailedRequest {
 
   private FirmwareStatus status;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public FirmwareStatusNotificationRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
@@ -24,37 +24,25 @@ package eu.chargetime.ocpp.model.firmware; /*
                                               SOFTWARE.
                                            */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Calendar;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 @XmlRootElement
 @XmlType(propOrder = {"location", "startTime", "stopTime", "retries", "retryInterval"})
-public class GetDiagnosticsRequest implements Request {
+public class GetDiagnosticsRequest extends DetailedRequest {
 
   private String location;
   private int retries;
   private int retryInterval;
   private Calendar startTime;
   private Calendar stopTime;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean transactionRelated() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
@@ -27,37 +27,25 @@ package eu.chargetime.ocpp.model.firmware;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Calendar;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
 @XmlType(propOrder = {"location", "retries", "retrieveDate", "retryInterval"})
-public class UpdateFirmwareRequest implements Request {
+public class UpdateFirmwareRequest extends DetailedRequest {
   private String location;
   private Integer retries;
   private Calendar retrieveDate;
   private Integer retryInterval;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public UpdateFirmwareRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionRequest.java
@@ -26,26 +26,12 @@ package eu.chargetime.ocpp.model.localauthlist;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class GetLocalListVersionRequest implements Request {
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
+public class GetLocalListVersionRequest extends DetailedRequest {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
@@ -26,31 +26,18 @@ package eu.chargetime.ocpp.model.localauthlist;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class SendLocalListRequest implements Request {
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
+public class SendLocalListRequest extends DetailedRequest {
 
   private int listVersion = 0;
   private AuthorizationData[] localAuthorizationList = null;
   private UpdateType updateType = null;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public SendLocalListRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/ohme/LocationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/ohme/LocationRequest.java
@@ -6,11 +6,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 @XmlRootElement
 @XmlType(propOrder = {"location_lat", "location_long", "location_prec"})
-public class LocationRequest implements Request {
+public class LocationRequest extends DetailedRequest {
 
 	private String location_lat;
 
@@ -19,20 +20,6 @@ public class LocationRequest implements Request {
 	private String location_prec;
 
 	private Collection<CellTower> cellTowers;
-	/**
-	 * The unique identifier of the request that was used when the request was transmitted over the network.
-	 */
-	private String requestId;
-
-	@Override
-	public void setRequestId(String requestId) {
-		this.requestId = requestId;
-	}
-
-	@Override
-	public String getRequestId() {
-		return requestId;
-	}
 
 	public Collection<CellTower> getCellTowers() {
 		return cellTowers;
@@ -79,4 +66,16 @@ public class LocationRequest implements Request {
 	public void setLocation_prec(String location_prec) {
 		this.location_prec = location_prec;
 	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("location_lat", location_lat)
+				.add("location_long", location_long)
+				.add("location_prec", location_prec)
+				.add("cellTowers", cellTowers)
+				.add("isValid", validate())
+				.toString();
+	}
+
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageRequest.java
@@ -27,34 +27,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
 @XmlRootElement
 @XmlType(propOrder = {"requestedMessage", "connectorId"})
-public class TriggerMessageRequest implements Request {
+public class TriggerMessageRequest extends DetailedRequest {
 
   private Integer connectorId;
   private TriggerMessageRequestType requestedMessage;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public TriggerMessageRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationRequest.java
@@ -1,10 +1,12 @@
 package eu.chargetime.ocpp.model.reservation;
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /*
  * ChargeTime.eu - Java-OCA-OCPP
@@ -35,22 +37,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class CancelReservationRequest implements Request {
+public class CancelReservationRequest extends DetailedRequest {
   private Integer reservationId;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public CancelReservationRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowRequest.java
@@ -1,14 +1,16 @@
 package eu.chargetime.ocpp.model.reservation;
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.utilities.ModelUtil;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Calendar;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.utilities.ModelUtil;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /*
  * ChargeTime.eu - Java-OCA-OCPP
@@ -40,7 +42,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "expiryDate", "idTag", "parentIdTag", "reservationId"})
-public class ReserveNowRequest implements Request {
+public class ReserveNowRequest extends DetailedRequest {
 
   private static final int ID_TAG_MAX_LENGTH = 20;
   private static final String ERROR_MESSAGE = "Exceeded limit of " + ID_TAG_MAX_LENGTH + " chars";
@@ -50,20 +52,6 @@ public class ReserveNowRequest implements Request {
   private String idTag;
   private String parentIdTag;
   private Integer reservationId;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public ReserveNowRequest() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileRequest.java
@@ -1,12 +1,14 @@
 package eu.chargetime.ocpp.model.smartcharging;
 
-import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
+import eu.chargetime.ocpp.utilities.MoreObjects;
 
 /*
  * ChargeTime.eu - Java-OCA-OCPP
@@ -36,25 +38,11 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 
 @XmlRootElement
-public class ClearChargingProfileRequest implements Request {
+public class ClearChargingProfileRequest extends DetailedRequest {
   private Integer id;
   private Integer connectorId;
   private ChargingProfilePurposeType chargingProfilePurpose;
   private Integer stackLevel;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * The ID of the charging profile to clear.

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
@@ -1,13 +1,15 @@
 package eu.chargetime.ocpp.model.smartcharging;
 
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.model.core.ChargingProfile;
 import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
-import java.util.Objects;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
 /*
  * ChargeTime.eu - Java-OCA-OCPP
@@ -36,23 +38,9 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 
 @XmlRootElement
-public class SetChargingProfileRequest implements Request {
+public class SetChargingProfileRequest extends DetailedRequest {
   private Integer connectorId;
   private ChargingProfile csChargingProfiles;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public SetChargingProfileRequest() {}
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationRequest.java
@@ -25,32 +25,20 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import java.util.Objects;
+
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.model.basic.types.BootReasonEnumType;
 import eu.chargetime.ocpp.model.basic.types.ChargingStationType;
 import eu.chargetime.ocpp.model.validation.RequiredValidator;
 import eu.chargetime.ocpp.utilities.MoreObjects;
-import java.util.Objects;
 
 /** Sent by the Charging Station to the CSMS. */
-public class BootNotificationRequest implements Request {
+public class BootNotificationRequest extends DetailedRequest {
   private transient RequiredValidator validator = new RequiredValidator();
 
   private BootReasonEnumType reason;
   private ChargingStationType chargingStation;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   public BootNotificationRequest() {}
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesRequest.java
@@ -25,29 +25,16 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
-import eu.chargetime.ocpp.model.basic.types.GetVariableDataType;
-import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetVariablesRequest implements Request {
+import eu.chargetime.ocpp.model.DetailedRequest;
+import eu.chargetime.ocpp.model.basic.types.GetVariableDataType;
+import eu.chargetime.ocpp.utilities.MoreObjects;
+
+public class GetVariablesRequest extends DetailedRequest {
 
   private GetVariableDataType[] getVariableData;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   /**
    * List of requested variables.

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesRequest.java
@@ -25,35 +25,22 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import java.util.Arrays;
+import java.util.Objects;
+
+import eu.chargetime.ocpp.model.DetailedRequest;
 import eu.chargetime.ocpp.model.basic.types.SetVariableDataType;
 import eu.chargetime.ocpp.model.validation.RequiredValidator;
 import eu.chargetime.ocpp.model.validation.Validator;
 import eu.chargetime.ocpp.utilities.MoreObjects;
-import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * This contains the field definition of the SetVariablesRequest PDU sent by the CSMS to the
  * Charging Station.
  */
-public class SetVariablesRequest implements Request {
+public class SetVariablesRequest extends DetailedRequest {
   private transient Validator<Object> requiredValidator = new RequiredValidator();
   private SetVariableDataType[] setVariableData;
-  /**
-   * The unique identifier of the request that was used when the request was transmitted over the network.
-   */
-  private String requestId;
-
-  @Override
-  public void setRequestId(String requestId) {
-    this.requestId = requestId;
-  }
-
-  @Override
-  public String getRequestId() {
-    return requestId;
-  }
 
   @Override
   public boolean transactionRelated() {


### PR DESCRIPTION
Adds a new DetailedRequest class which implements Request but holds the deviceId. It also holds additional details that can be passed in from a service using this library.

All of the requests now extend this class. 

This information is consumed and tagged onto our message accordingly before passing through to the appropriate handlers.

[Links to this jira ticket](https://ohmenergy.atlassian.net/browse/FIR-979)

Related PR:
- [OCPP lib](https://github.com/OhmEnergy/Java-OCA-OCPP/pull/10)
- [ohme-server-api](https://github.com/OhmEnergy/ohme-server-api/pull/2746)
- [virtual cable changes](https://github.com/OhmEnergy/ohme-virtual-cable/pull/8)